### PR TITLE
Adds a check that the render galley is also XML when getting the best XML galley.

### DIFF
--- a/logic.py
+++ b/logic.py
@@ -78,7 +78,7 @@ def get_best_portico_xml_galley(article, galleys):
         public=True,
     ).order_by('-file__date_uploaded')
 
-    if article.render_galley:
+    if article.render_galley and article.render_galley.file.mime_type in files.XML_MIMETYPES:
         return article.render_galley
 
     if xml_galleys:


### PR DESCRIPTION
A simple bug fix from an issue picked up by Arizona. When a journal has an HTML render galley it the portico plugin uses it as the best XML galley. Added a check that the render galley is _also_ an XML file.